### PR TITLE
Cleaning up Android changes to work with v3

### DIFF
--- a/cocos/platform/android/javaactivity-android.cpp
+++ b/cocos/platform/android/javaactivity-android.cpp
@@ -44,10 +44,10 @@ THE SOFTWARE.
 
 using namespace cocos2d;
 
+extern void cocos_android_app_init(JNIEnv* env, jobject thiz) __attribute__((weak));
+
 extern "C"
 {
-
-extern void cocos_android_app_init(JNIEnv* env, jobject thiz) __attribute__((weak));
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved)
 {


### PR DESCRIPTION
This was originally in the c++ namespace. A previous change moved into the C namespace so the function name was not mangled. We are reverting this change and updated DiscoBee's method to be in the c++ namespace.
