### PR TITLE
TextureManager: Prevents double loading textures

### DIFF
--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -225,6 +225,7 @@ protected:
 
     int _asyncRefCount;
 
+    mutable std::mutex _texturesMutex;
     std::unordered_map<std::string, Texture2D*> _textures;
 };
 


### PR DESCRIPTION
CCTextureManager:
- Now prevents loading a resource in the BG if it discovers it is already loaded (occurs in the BG thread)
- Added mutex protection to _textures (cache texture hashmap) which is read and modified in two different threads
