### PR TITLE
Android: Expansion files no longer use ZipFile for reading data.

### DIFF
--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -226,9 +226,9 @@ Data FileUtilsAndroid::getData(const std::string& filename, bool forString)
         
         // Expansion files take priority
         std::string expansionFilePath = "assets/" + relativePath;
-        for (auto it = _expansionFiles.rbegin(); it != _expansionFiles.rend() && data == nullptr; ++it)
+        for (auto it = _expansionFileNames.rbegin(); it != _expansionFileNames.rend() && data == nullptr; ++it)
         {
-            data = (*it)->getFileData(expansionFilePath, &size);
+            data = getFileDataFromZip(*it, expansionFilePath, &size);
         }
         
         // Try from the APK
@@ -358,9 +358,14 @@ unsigned char* FileUtilsAndroid::getFileData(const std::string& filename, const 
         
         // Expansion files take priority
         std::string expansionFilePath = "assets/" + relativePath;
-        for (auto it = _expansionFiles.rbegin(); it != _expansionFiles.rend() && data == nullptr; ++it)
+        for (auto it = _expansionFileNames.rbegin(); it != _expansionFileNames.rend() && data == nullptr; ++it)
         {
-            data = (*it)->getFileData(expansionFilePath, size);
+            ssize_t localSize = 0;
+            data = getFileDataFromZip(*it, expansionFilePath, &localSize);
+            if ( data )
+            {
+                *size = localSize;
+            }
         }
         
         // Try from the APK
@@ -451,6 +456,7 @@ void FileUtilsAndroid::addExpansionFile(const std::string& expansionFile)
 {
     std::string expansionPath = getExternalStorageDirectory() + "/Android/obb/" + getPackageNameJNI() + "/" + expansionFile;
     _expansionFiles.push_back(new ZipFile(expansionPath, "assets/"));
+    _expansionFileNames.push_back(expansionPath);
     
     LOGI("Adding expansion file to search path %s", expansionPath.c_str());
 }

--- a/cocos/platform/android/CCFileUtils-android.h
+++ b/cocos/platform/android/CCFileUtils-android.h
@@ -96,6 +96,7 @@ private:
     static AAssetManager* assetmanager;
     
     std::vector<cocos2d::ZipFile*> _expansionFiles;
+    std::vector<std::string> _expansionFileNames;
 };
 
 // end of platform group


### PR DESCRIPTION
The FileUtils still use ZipFile to verify the file exists. However,
ZipFile displayed serious problems with consistently reading data
from the ZipFile. getDataFromZipFile is now used for that
