### PR TITLE
Cocos2dx CS Modifications

### DIFF
--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -759,7 +759,10 @@ Node* CSLoader::nodeWithFlatBuffersFile(const std::string &fileName)
 //    CCLOG("textureSize = %d", textureSize);
     for (int i = 0; i < textureSize; ++i)
     {
-        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(textures->Get(i)->c_str());        
+      if ( _asyncLoadingPlistSet.find(textures->Get(i)->c_str()) == _asyncLoadingPlistSet.end() )
+      {
+        SpriteFrameCache::getInstance()->addSpriteFramesWithFile(textures->Get(i)->c_str());
+      }
     }
     
     Node* node = nodeWithFlatBuffers(csparsebinary->nodeTree());
@@ -1095,6 +1098,11 @@ Node* CSLoader::createNodeWithFlatBuffersForSimulator(const std::string& filenam
     fbs->deleteFlatBufferBuilder();
     
     return node;
+}
+
+void CSLoader::setAsyncLoadingPlist(const std::string& plist)
+{
+  _asyncLoadingPlistSet.insert(plist);
 }
 
 Node* CSLoader::nodeWithFlatBuffersForSimulator(const flatbuffers::NodeTree *nodetree)

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -146,6 +146,9 @@ protected:
     std::string _monoCocos2dxVersion;
     
     Node* _rootNode;
+  
+    std::string _lastChildrenReaderPrefix;
+    std::vector<std::string> _childrenReaderPrefixStack;
 //    std::vector<Node*> _loadingNodeParentHierarchy;
 };
 

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -30,6 +30,8 @@
 #include "cocos2d.h"
 #include "base/ObjectFactory.h"
 
+#include <unordered_set>
+
 namespace flatbuffers
 {
     struct FlatBufferBuilder;
@@ -100,7 +102,8 @@ public:
     
     cocos2d::Node* createNodeWithFlatBuffersForSimulator(const std::string& filename);
     cocos2d::Node* nodeWithFlatBuffersForSimulator(const flatbuffers::NodeTree* nodetree);
-    
+  
+    void setAsyncLoadingPlist(const std::string& plist);
 protected:
     
     cocos2d::Node* loadNode(const rapidjson::Value& json);
@@ -144,7 +147,10 @@ protected:
     std::string _jsonPath;
     
     std::string _monoCocos2dxVersion;
-    
+  
+    // Contains all plists that will be loaded asynchronously
+    std::unordered_set<std::string> _asyncLoadingPlistSet;
+  
     Node* _rootNode;
 //    std::vector<Node*> _loadingNodeParentHierarchy;
 };

--- a/cocos/editor-support/cocostudio/WidgetReader/NodeReaderProtocol.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/NodeReaderProtocol.h
@@ -57,6 +57,7 @@ namespace cocostudio
                                                                                      flatbuffers::FlatBufferBuilder* builder) = 0;
         virtual void setPropsWithFlatBuffers(cocos2d::Node* node, const flatbuffers::Table* nodeOptions) = 0;
         virtual cocos2d::Node* createNodeWithFlatBuffers(const flatbuffers::Table* nodeOptions) = 0;
+        virtual std::string childrenReaderPrefix() { return ""; }
     };
 }
 


### PR DESCRIPTION
1) Can now specify plists to ignore to autoload
2) NodeReaders can specify childReaderPrefix, e.g. prefix appended to all node readers that are children of that Node.
