### PR TITLE
Expansion zip fix

### DIFF
--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -562,38 +562,6 @@ bool ZipFile::setFilter(const std::string &filter)
         // clear existing file list
         _data->fileList.clear();
       
-        CC_BREAK_IF(unzGoToFirstFile(_data->zipFile) != UNZ_OK);
-        std::string curFilePath;
-        unz_file_info curFileInfo;
-        int err = 0;
-      
-        do
-        {
-          CC_BREAK_IF(getCurrentFileInfo(&curFilePath, &curFileInfo) != UNZ_OK);
-          unz_file_pos posInfo;
-          int posErr = unzGetFilePos(_data->zipFile, &posInfo);
-          if (posErr == UNZ_OK)
-          {
-            // cache info about filtered files only (like 'assets/')
-            if (filter.empty()
-                || curFilePath.substr(0, filter.length()) == filter)
-            {
-              ZipEntryInfo entry;
-              entry.pos = posInfo;
-              entry.uncompressed_size = static_cast<uLong>(curFileInfo.uncompressed_size);
-              _data->fileList[curFilePath] = entry;
-              
-              CCLOG("ZipUtils: Added entry %s, uncompressed_size=%lu", curFilePath.c_str(), entry.uncompressed_size);
-            }
-          }
-          
-          err = unzGoToNextFile(_data->zipFile);
-        } while (err == UNZ_OK);
-      
-        ret = true;
-      
-      /*
-        
         // UNZ_MAXFILENAMEINZIP + 1 - it is done so in unzLocateFile
         char szCurrentFileName[UNZ_MAXFILENAMEINZIP + 1];
         unz_file_info64 fileInfo;
@@ -622,7 +590,7 @@ bool ZipFile::setFilter(const std::string &filter)
             err = unzGoToNextFile64(_data->zipFile, &fileInfo,
                                     szCurrentFileName, sizeof(szCurrentFileName) - 1);
         }
-        ret = true;*/
+        ret = true;
         
     } while(false);
     
@@ -644,14 +612,6 @@ bool ZipFile::fileExists(const std::string &fileName) const
 
 unsigned char *ZipFile::getFileData(const std::string &fileName, ssize_t *size)
 {
-    CCLOG("ZipUtils: Attempting to read %s", fileName.c_str());
-  
-    if ( !fileExists(fileName) )
-    {
-      CCLOG("ZipUtils: File does not exist");
-      return nullptr;
-    }
-  
     unsigned char * buffer = nullptr;
     if (size)
         *size = 0;

--- a/cocos/base/ZipUtils.h
+++ b/cocos/base/ZipUtils.h
@@ -288,6 +288,8 @@ typedef struct unz_file_info_s unz_file_info;
         
         /** Internal data like zip file pointer / file list array and so on */
         ZipFilePrivate *_data;
+      
+        std::string _zipFileName;
     };
 } // end of namespace cocos2d
 #endif // __SUPPORT_ZIPUTILS_H__

--- a/cocos/platform/android/CCFileUtils-android.cpp
+++ b/cocos/platform/android/CCFileUtils-android.cpp
@@ -227,9 +227,9 @@ Data FileUtilsAndroid::getData(const std::string& filename, bool forString)
         
         // Expansion files take priority
         std::string expansionFilePath = "assets/" + relativePath;
-        for (auto it = _expansionFileNames.rbegin(); it != _expansionFileNames.rend() && data == nullptr; ++it)
+        for (auto it = _expansionFiles.rbegin(); data == nullptr && it != _expansionFiles.rend(); ++it)
         {
-            data = getFileDataFromZip(*it, expansionFilePath, &size);
+          data = (*it)->getFileData(expansionFilePath, &size);
         }
         
         // Try from the APK
@@ -359,10 +359,10 @@ unsigned char* FileUtilsAndroid::getFileData(const std::string& filename, const 
         
         // Expansion files take priority
         std::string expansionFilePath = "assets/" + relativePath;
-        for (auto it = _expansionFileNames.rbegin(); it != _expansionFileNames.rend() && data == nullptr; ++it)
+        for (auto it = _expansionFiles.rbegin(); data == nullptr && it != _expansionFiles.rend(); ++it)
         {
           ssize_t localSize = 0;
-          data = getFileDataFromZip(*it, expansionFilePath, &localSize);
+          data = (*it)->getFileData(expansionFilePath, &localSize);
           if ( data )
           {
             *size = localSize;


### PR DESCRIPTION
Searching for the file location in the obb (zip) file was causing slow downs. 
So, Expansion files now use the ZipFile implementation.
The ZipFile implementation has also been fixed to be thread safe
