### PR TITLE
Spine’s SkeletonRenderer update method is called on onEnter method to…

### DIFF
--- a/cocos/editor-support/spine-runtimes/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine-runtimes/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
@@ -383,6 +383,7 @@ void SkeletonRenderer::onEnter () {
 #endif
 	Node::onEnter();
 	scheduleUpdate();
+  update(0.0f);
 }
 
 void SkeletonRenderer::onExit () {


### PR DESCRIPTION
… set spine animations during scene initialization.